### PR TITLE
EODHP-786 Harvest Airbus optical data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,5 +163,8 @@ cython_debug/
 
 *.bak
 
+# VS Code
+.vscode/
+
 # Configuration files
 .pre-commit-config.yaml

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DOCKERREPO ?= public.ecr.aws/n1b3o1k2
 dockerbuild:
 	DOCKER_BUILDKIT=1 docker build -t ${IMAGENAME}:${VERSION} .
 
-dockerpush: dockerbuild testdocker
+dockerpush: dockerbuild
 	docker tag ${IMAGENAME}:${VERSION} ${DOCKERREPO}/${IMAGENAME}:${VERSION}
 	docker push ${DOCKERREPO}/${IMAGENAME}:${VERSION}
 

--- a/airbus_harvester/__main__.py
+++ b/airbus_harvester/__main__.py
@@ -126,9 +126,15 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
                 logging.error(e)
                 raise
         elif config["pagination_method"] == "counter":
-            config["body"]["startPage"] = url_count + 1
             if not body["features"]:
                 next_url = None
+            else:
+                # The counter can only go up to 50. Limit the search by last update date
+                if (url_count + 1) % 50 == 0:
+                    config["body"][
+                        "lastUpdateDate"
+                    ] = f"[2018-10-03T12:00:00Z,{entry['properties']['lastUpdateDate']}]"
+                config["body"]["startPage"] = (url_count % 50) + 1
 
         logging.info(f"Page {url_count} next URL: {next_url}")
 

--- a/airbus_harvester/__main__.py
+++ b/airbus_harvester/__main__.py
@@ -22,6 +22,11 @@ logging.basicConfig(
 minimum_message_entries = int(os.environ.get("MINIMUM_MESSAGE_ENTRIES", 100))
 
 
+def load_config(config_path):
+    with open(config_path, "r") as f:
+        return json.load(f)
+
+
 @click.group()
 # you can implement any global flags here that will apply to all commands, e.g. debug
 # @click.option('--debug/--no-debug', default=False) # don't feel the need to implement this, just an example
@@ -56,13 +61,18 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
     pulsar_url = os.environ.get("PULSAR_URL")
     pulsar_client = PulsarClient(pulsar_url)
 
+    config_key = os.getenv("HARVESTER_CONFIG_KEY", "")
+    config = load_config("airbus_harvester/config.json").get(config_key.upper())
+    if not config:
+        logging.error(f"Configuration key {config_key} not found in config file.")
+
     harvested_keys = {"added_keys": set(), "updated_keys": set()}
 
-    logging.info("Harvesting from Airbus")
+    logging.info(f"Harvesting from Airbus {config_key}")
 
     key_root = "git-harvester/supported-datasets/airbus"
 
-    metadata_s3_key = "harvested-metadata/airbus"
+    metadata_s3_key = f"harvested-metadata/{config['collection_name']}"
     previously_harvested = get_metadata(s3_bucket, metadata_s3_key, s3_client)
     logging.info(f"Previously harvested URLs: {previously_harvested}")
     latest_harvested = {}
@@ -74,13 +84,13 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
         catalogue_key, catalogue_data, previous_hash, harvested_keys, s3_bucket, s3_client
     )
 
-    collection_key = f"{key_root}/airbus_sar_data.json"
+    collection_key = f"{key_root}/{config['collection_name']}.json"
 
     catalogue_data_summary = previously_harvested.pop("summary", None)
     if not catalogue_data_summary:
         catalogue_data_summary = {"start_time": [], "stop_time": [], "coordinates": []}
 
-    next_url = "https://sar.api.oneatlas.airbus.com/v1/sar/catalogue/replication"
+    next_url = config["url"]
     url_count = 0
 
     deleted_keys = []
@@ -88,15 +98,13 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
     while next_url:
         url_count += 1
 
-        body = get_next_page(next_url)
+        body = get_next_page(next_url, config)
 
         for entry in body["features"]:
-            catalogue_data_summary = add_to_catalogue_data_summary(catalogue_data_summary, entry)
-
-            data = generate_stac_item(entry)
+            data = generate_stac_item(entry, config)
             try:
-                file_name = f"{entry['properties']['acquisitionId']}.json"
-                key = f"{key_root}/airbus_sar_data/{file_name}"
+                file_name = f"{entry['properties'][config['item_id_key']]}.json"
+                key = f"{key_root}/{config['collection_name']}/{file_name}"
 
                 previous_hash = previously_harvested.pop(key, None)
                 harvested_keys, latest_harvested[key] = compare_to_previous_version(
@@ -105,20 +113,30 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
             except KeyError:
                 logging.error(f"Invalid entry in {next_url}")
 
+            catalogue_data_summary = add_to_catalogue_data_summary(
+                catalogue_data_summary, json.loads(data)
+            )
+
         catalogue_data_summary = simplify_catalogue_data_summary(catalogue_data_summary)
 
-        try:
-            next_url = body.get("_links").get("next")
-        except AttributeError as e:
-            logging.error(e)
-            raise
+        if config["pagination_method"] == "link":
+            try:
+                next_url = body.get("_links").get("next")
+            except AttributeError as e:
+                logging.error(e)
+                raise
+        elif config["pagination_method"] == "counter":
+            config["body"]["startPage"] = url_count + 1
+            if not body["features"]:
+                next_url = None
+
         logging.info(f"Page {url_count} next URL: {next_url}")
 
         summary = get_stac_collection_summary(catalogue_data_summary)
 
         # Collection updates every loop so that start/stop times and bbox values are the latest
         # ones from the Airbus catalogue
-        collection_data = generate_stac_collection(summary)
+        collection_data = generate_stac_collection(summary, config)
         last_run_hash = latest_harvested.get(collection_key)
         previous_hash = last_run_hash if last_run_hash else previously_harvested.get(collection_key)
 
@@ -139,7 +157,7 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
             upload_file_s3(json.dumps(latest_harvested), s3_bucket, metadata_s3_key, s3_client)
 
             output_data = {
-                "id": f"{workspace_name}/airbus_{url_count}",
+                "id": f"{workspace_name}/{config['collection_name']}_{url_count}",
                 "workspace": workspace_name,
                 "bucket_name": s3_bucket,
                 "added_keys": list(harvested_keys["added_keys"]),
@@ -220,17 +238,21 @@ def compare_to_previous_version(
     return harvested_keys, file_hash
 
 
-def add_to_catalogue_data_summary(all_data, data) -> dict:
+def add_to_catalogue_data_summary(all_data: dict, data: dict) -> dict:
     """Combines new data with existing data for whole catalogue"""
-    all_data["coordinates"].append(data["geometry"]["coordinates"][0][0])
-    all_data["start_time"].append(data["properties"]["startTime"])
-    all_data["stop_time"].append(data["properties"]["stopTime"])
+    all_data["coordinates"] += data["geometry"]["coordinates"][0]
+    all_data["start_time"].append(
+        data["properties"].get("start_datetime", data["properties"].get("datetime"))
+    )
+    all_data["stop_time"].append(
+        data["properties"].get("end_datetime", data["properties"].get("datetime"))
+    )
 
     return all_data
 
 
 def simplify_catalogue_data_summary(all_data: dict) -> dict:
-    """Finds the bbox, start and stop time of all data so far and removes any superfluous values"""
+    """Finds the coordinates containing bbox values, and start and stop time of all data so far"""
     biggest_lat = smallest_lat = biggest_long = smallest_long = all_data["coordinates"][0]
 
     for coordinates in all_data["coordinates"]:
@@ -276,14 +298,19 @@ def generate_access_token(env: str = "dev") -> str:
     return response.json().get("access_token")
 
 
-def get_next_page(url: str, retry_count: int = 0) -> dict:
+def get_next_page(url: str, config: dict, retry_count: int = 0) -> dict:
     """Collects body of next page of Airbus data"""
 
     try:
-        access_token = generate_access_token(env="prod")
+        headers = {"accept": "application/json"}
+        if config["auth_env"]:
+            access_token = generate_access_token(config["auth_env"])
+            headers["Authorization"] = "Bearer " + access_token
 
-        headers = {"accept": "application/json", "Authorization": "Bearer " + access_token}
-        response = requests.get(url, headers=headers)
+        if config["request_method"].upper() == "POST":
+            response = requests.post(url, json=config["body"], headers=headers)
+        else:
+            response = requests.get(url, json=config["body"], headers=headers)
         response.raise_for_status()
 
         return response.json()
@@ -293,7 +320,7 @@ def get_next_page(url: str, retry_count: int = 0) -> dict:
         if retry_count > 3:
             raise
 
-        return get_next_page(url, retry_count=retry_count + 1)
+        return get_next_page(url, config, retry_count=retry_count + 1)
 
 
 def get_file_hash(data: str) -> str:
@@ -328,7 +355,7 @@ def get_metadata(bucket: str, key: str, s3_client: boto3.client) -> dict:
     return previously_harvested
 
 
-def coordinates_to_bbox(coordinates: dict) -> list:
+def coordinates_to_bbox(coordinates: list) -> list:
     """Finds the biggest and smallest x and y coordinates"""
 
     unzipped = list(zip(*coordinates, strict=False))
@@ -351,82 +378,22 @@ def get_stac_collection_summary(all_data: dict) -> dict:
     }
 
 
-def generate_stac_collection(all_data_summary: dict) -> str:
+def generate_stac_collection(all_data_summary: dict, config: dict) -> str:
     """Top level collection for Airbus data"""
 
-    stac_collection = {
-        "type": "Collection",
-        "id": "airbus_sar_data",
-        "stac_version": "1.0.0",
-        "stac_extensions": [
-            "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
-        ],
-        "description": (
-            "The German TerraSAR-X / TanDEM-X satellite formation and the Spanish PAZ satellite "
-            "(managed by Hisdesat Servicios Estratégicos S.A.) are being operated in the same "
-            "orbit tube and feature identical ground swaths and imaging modes - allowing Airbus "
-            "and Hisdesat to establish a unique commercial Radar Constellation. The satellites "
-            "carry a high frequency X-band Synthetic Aperture Radar (SAR) sensor in order to "
-            "acquire datasets ranging from very high-resolution imagery to wide area coverage."
-        ),
-        "links": [],
-        "title": "Airbus SAR Data",
-        "geometry": {"type": "Polygon"},
-        "extent": {
-            "spatial": {"bbox": [all_data_summary["bbox"]]},
-            "temporal": {
-                "interval": [[all_data_summary["start_time"], all_data_summary["stop_time"]]]
-            },
-        },
-        "license": "proprietary",
-        "keywords": ["airbus"],
-        "summaries": {
-            "platform": ["TSX-1", "PAZ-1", "TDX-1"],
-            "constellation": ["TSX", "PAZ"],
-            "sar:product_type": ["SSC", "MGD", "GEC", "EEC"],
-            "sat:orbit_state": ["ascending", "descending"],
-            "sar:polarizations": [
-                ["VV", "VH"],
-                ["HH", "HV"],
-                ["HH", "VV"],
-                ["VV"],
-                ["VH"],
-                ["HH"],
-                ["HV"],
-            ],
-            "sar:frequency_band": ["X"],
-            "sar:instrument_mode": [
-                "SAR_ST_S",
-                "SAR_HS_S",
-                "SAR_HS_S_300",
-                "SAR_HS_S_150",
-                "SAR_HS_D",
-                "SAR_HS_D_300",
-                "SAR_HS_D_150",
-                "SAR_SL_S",
-                "SAR_SL_D",
-                "SAR_SM_S",
-                "SAR_SM_D",
-                "SAR_SC_S",
-                "SAR_WS_S",
-            ],
-            "sar:center_frequency": [9.65],
-            "sar:observation_direction": ["right", "left"],
-        },
-        "item_assets": {
-            "thumbnail": {
-                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
-                "roles": ["thumbnail"],
-                "title": "Thumbnail Image",
-            }
-        },
+    stac_template = load_config(f"airbus_harvester/{config['collection_name']}.json")
+
+    stac_template["extent"] = {
+        "spatial": {"bbox": [all_data_summary["bbox"]]},
+        "temporal": {"interval": [[all_data_summary["start_time"], all_data_summary["stop_time"]]]},
     }
-    return json.dumps(stac_collection, indent=4)
+    return json.dumps(stac_template, indent=4)
 
 
-def handle_quicklook_url(data, links, assets, mapped_keys):
-    """Convert quicklook URL to thumbnail asset"""
+def handle_external_url(
+    data: dict, links: list, assets: dict, mapped_keys: set, name: str, path: str
+):
+    """Convert external URL to link and asset"""
     mime_types = {
         ".tiff": "image/tiff; application=geotiff; profile=cloud-optimized",
         ".tif": "image/tiff; application=geotiff; profile=cloud-optimized",
@@ -435,21 +402,29 @@ def handle_quicklook_url(data, links, assets, mapped_keys):
         ".png": "image/png",
     }
 
-    if quicklook_url := data["properties"].get("quicklookUrl"):
-        file_extension = os.path.splitext(quicklook_url)[1].lower()
+    keys = path.split(".")
+    value = data
+    for key in keys:
+        value = value.get(key)
+        if value is None:
+            break
+    external_url = value if isinstance(value, str) else None
+
+    if external_url:
+        file_extension = os.path.splitext(external_url)[1].lower()
         mime_type = mime_types.get(file_extension, "application/octet-stream")
         links.append(
             {
-                "rel": "thumbnail",
-                "href": data["properties"]["quicklookUrl"],
+                "rel": name,
+                "href": external_url,
                 "type": mime_type,
             }
         )
-        assets["thumbnail"] = {
-            "href": data["properties"]["quicklookUrl"],
+        assets[name] = {
+            "href": external_url,
             "type": mime_type,
         }
-        mapped_keys.add("quicklookUrl")
+        mapped_keys.add(key)
 
 
 def modify_value(key, value) -> str:
@@ -463,36 +438,26 @@ def modify_value(key, value) -> str:
     return value
 
 
-def generate_stac_item(data) -> str:
+def generate_stac_item(data: dict, config: dict) -> str:
     """Catalogue items for Airbus data"""
     coordinates = data["geometry"]["coordinates"][0]
     bbox = coordinates_to_bbox(coordinates)
 
     mapped_keys = set()
-    properties = {"access": ["HTTPServer"], "sar:frequency_band": "X", "sar:center_frequency": 9.65}
+    properties = config["stac_properties"]
 
     links = []
     assets = {}
 
-    def map_if_exists(key, source_key):
-        if source_key in data["properties"]:
-            properties[key] = modify_value(source_key, data["properties"][source_key])
-            mapped_keys.add(source_key)
+    for stac_key, airbus_key in config["stac_properties_map"].items():
+        if airbus_key in data["properties"]:
+            properties[stac_key] = modify_value(airbus_key, data["properties"][airbus_key])
+            mapped_keys.add(airbus_key)
 
-    map_if_exists("datetime", "catalogueTime")
-    map_if_exists("start_datetime", "startTime")
-    map_if_exists("end_datetime", "stopTime")
-    map_if_exists("updated", "lastUpdateTime")
-    map_if_exists("sar:instrument_mode", "sensorMode")
-    map_if_exists("sar:polarizations", "polarizationChannels")
-    map_if_exists("sar:observation_direction", "lookDirection")
-    map_if_exists("sar:product_type", "productType")
-    map_if_exists("sat:platform_international_designator", "satellite")
-    map_if_exists("sat:orbit_state", "pathDirection")
-    map_if_exists("sat:relative_orbit", "relativeOrbit")
-    map_if_exists("sat:absolute_orbit", "absoluteOrbit")
-
-    handle_quicklook_url(data, links, assets, mapped_keys)
+    for url_config in config["external_urls"]:
+        handle_external_url(
+            data, links, assets, mapped_keys, url_config["name"], url_config["path"]
+        )
 
     for key, value in data["properties"].items():
         if key not in mapped_keys and value is not None:
@@ -501,12 +466,9 @@ def generate_stac_item(data) -> str:
     stac_item = {
         "type": "Feature",
         "stac_version": "1.0.0",
-        "stac_extensions": [
-            "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
-            "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
-        ],
-        "id": data["properties"]["acquisitionId"],
-        "collection": "airbus_sar_data",
+        "stac_extensions": config["stac_extensions"],
+        "id": data["properties"][config["item_id_key"]],
+        "collection": config["collection_name"],
         "geometry": {"type": "Polygon", "coordinates": [coordinates]},
         "bbox": bbox,
         "properties": properties,

--- a/airbus_harvester/airbus_phr_data.json
+++ b/airbus_harvester/airbus_phr_data.json
@@ -1,0 +1,42 @@
+{
+    "type": "Collection",
+    "id": "airbus_phr_data",
+    "stac_version": "1.0.0",
+    "stac_extensions": [],
+    "description": "The identical Pléiades 1A and Pléiades 1B satellites deliver 50cm imagery products with a 20km swath. Their location accuracy and image quality are excellent, making them an ideal source of data for both civil or military projects. The space and ground segment have been designed to provide data in record time, ensuring daily revisit capacity anywhere on the globe and unrivalled reliability when it comes to collecting new images.",
+    "links": [],
+    "title": "Airbus PHR Data",
+    "geometry": {
+        "type": "Polygon"
+    },
+    "extent": {
+        "spatial": {
+            "bbox": []
+        },
+        "temporal": {
+            "interval": []
+        }
+    },
+    "license": "proprietary",
+    "keywords": [
+        "airbus"
+    ],
+    "summaries": {
+        "platform": [
+            "PHR1A",
+            "PHR1B"
+        ],
+        "constellation": [
+            "PHR"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "thumbnail"
+            ],
+            "title": "Thumbnail Image"
+        }
+    }
+}

--- a/airbus_harvester/airbus_pneo_data.json
+++ b/airbus_harvester/airbus_pneo_data.json
@@ -1,0 +1,42 @@
+{
+    "type": "Collection",
+    "id": "airbus_pneo_data",
+    "stac_version": "1.0.0",
+    "stac_extensions": [],
+    "description": "Experience the forefront of Earth observation innovation with Pléiades Neo - Airbus's leading optical constellation featuring two identical 30cm resolution satellites renowned for their ultimate reactivity. Since its launch in 2021, this innovative constellation has revolutionised the landscape of Earth observation-based services, setting new standards of precision and reliability. Funded, manufactured, owned, and operated entirely by Airbus, Pléiades Neo reflects their unfailing commitment to excellence. Through meticulous optimisation of every stage of the imagery acquisition and delivery cycle, Airbus guarantees the provision of top-level Earth observation services.",
+    "links": [],
+    "title": "Airbus PNEO Data",
+    "geometry": {
+        "type": "Polygon"
+    },
+    "extent": {
+        "spatial": {
+            "bbox": []
+        },
+        "temporal": {
+            "interval": []
+        }
+    },
+    "license": "proprietary",
+    "keywords": [
+        "airbus"
+    ],
+    "summaries": {
+        "platform": [
+            "PNEO3",
+            "PNEO4"
+        ],
+        "constellation": [
+            "PNEO"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "thumbnail"
+            ],
+            "title": "Thumbnail Image"
+        }
+    }
+}

--- a/airbus_harvester/airbus_sar_data.json
+++ b/airbus_harvester/airbus_sar_data.json
@@ -1,0 +1,108 @@
+{
+    "type": "Collection",
+    "id": "airbus_sar_data",
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+    ],
+    "description": "The German TerraSAR-X / TanDEM-X satellite formation and the Spanish PAZ satellite (managed by Hisdesat Servicios Estratégicos S.A.) are being operated in the same orbit tube and feature identical ground swaths and imaging modes - allowing Airbus and Hisdesat to establish a unique commercial Radar Constellation. The satellites carry a high frequency X-band Synthetic Aperture Radar (SAR) sensor in order to acquire datasets ranging from very high-resolution imagery to wide area coverage.",
+    "links": [],
+    "title": "Airbus SAR Data",
+    "geometry": {
+        "type": "Polygon"
+    },
+    "extent": {
+        "spatial": {
+            "bbox": []
+        },
+        "temporal": {
+            "interval": []
+        }
+    },
+    "license": "proprietary",
+    "keywords": [
+        "airbus"
+    ],
+    "summaries": {
+        "platform": [
+            "TSX-1",
+            "PAZ-1",
+            "TDX-1"
+        ],
+        "constellation": [
+            "TSX",
+            "PAZ"
+        ],
+        "sar:product_type": [
+            "SSC",
+            "MGD",
+            "GEC",
+            "EEC"
+        ],
+        "sat:orbit_state": [
+            "ascending",
+            "descending"
+        ],
+        "sar:polarizations": [
+            [
+                "VV",
+                "VH"
+            ],
+            [
+                "HH",
+                "HV"
+            ],
+            [
+                "HH",
+                "VV"
+            ],
+            [
+                "VV"
+            ],
+            [
+                "VH"
+            ],
+            [
+                "HH"
+            ],
+            [
+                "HV"
+            ]
+        ],
+        "sar:frequency_band": [
+            "X"
+        ],
+        "sar:instrument_mode": [
+            "SAR_ST_S",
+            "SAR_HS_S",
+            "SAR_HS_S_300",
+            "SAR_HS_S_150",
+            "SAR_HS_D",
+            "SAR_HS_D_300",
+            "SAR_HS_D_150",
+            "SAR_SL_S",
+            "SAR_SL_D",
+            "SAR_SM_S",
+            "SAR_SM_D",
+            "SAR_SC_S",
+            "SAR_WS_S"
+        ],
+        "sar:center_frequency": [
+            9.65
+        ],
+        "sar:observation_direction": [
+            "right",
+            "left"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "thumbnail"
+            ],
+            "title": "Thumbnail Image"
+        }
+    }
+}

--- a/airbus_harvester/airbus_spot_data.json
+++ b/airbus_harvester/airbus_spot_data.json
@@ -1,0 +1,42 @@
+{
+    "type": "Collection",
+    "id": "airbus_spot_data",
+    "stac_version": "1.0.0",
+    "stac_extensions": [],
+    "description": "The SPOT (from French \"Satellite pour l'Observation de la Terre\") series has been supplying high-resolution, wide-area optical imagery since 1986. The latest satellites in the series, SPOT 6 and SPOT 7, are commercial satellites owned by Airbus Defence and Space, and assure data continuity through to 2024. All of the SPOT satellites provide imagery in panchromatic and multispectral bands with a swath of 60 km.",
+    "links": [],
+    "title": "Airbus SPOT Data",
+    "geometry": {
+        "type": "Polygon"
+    },
+    "extent": {
+        "spatial": {
+            "bbox": []
+        },
+        "temporal": {
+            "interval": []
+        }
+    },
+    "license": "proprietary",
+    "keywords": [
+        "airbus"
+    ],
+    "summaries": {
+        "platform": [
+            "SPOT6",
+            "SPOT7"
+        ],
+        "constellation": [
+            "SPOT"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "roles": [
+                "thumbnail"
+            ],
+            "title": "Thumbnail Image"
+        }
+    }
+}

--- a/airbus_harvester/config.json
+++ b/airbus_harvester/config.json
@@ -1,0 +1,189 @@
+{
+    "SAR": {
+        "collection_name": "airbus_sar_data",
+        "url": "https://sar.api.oneatlas.airbus.com/v1/sar/catalogue/replication",
+        "auth_env": "prod",
+        "body": null,
+        "request_method": "GET",
+        "stac_properties": {
+            "access": [
+                "HTTPServer"
+            ],
+            "sar:frequency_band": "X",
+            "sar:center_frequency": 9.65
+        },
+        "stac_properties_map": {
+            "datetime": "catalogueTime",
+            "start_datetime": "startTime",
+            "end_datetime": "stopTime",
+            "updated": "lastUpdateTime",
+            "sar:instrument_mode": "sensorMode",
+            "sar:polarizations": "polarizationChannels",
+            "sar:observation_direction": "lookDirection",
+            "sar:product_type": "productType",
+            "sat:platform_international_designator": "satellite",
+            "sat:orbit_state": "pathDirection",
+            "sat:relative_orbit": "relativeOrbit",
+            "sat:absolute_orbit": "absoluteOrbit"
+        },
+        "external_urls": [
+            {
+                "name": "thumbnail",
+                "path": "properties.quicklookUrl"
+            }
+        ],
+        "stac_extensions": [
+            "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
+            "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+        ],
+        "item_id_key": "acquisitionId",
+        "pagination_method": "link"
+    },
+    "SPOT": {
+        "collection_name": "airbus_spot_data",
+        "url": "https://search.foundation.api.oneatlas.airbus.com/api/v2/opensearch",
+        "auth_env": null,
+        "body": {
+            "itemsPerPage": 200,
+            "sortBy": "-lastUpdateDate",
+            "startPage": 1,
+            "constellation": "SPOT",
+            "processingLevel": "ALBUM",
+            "workspace": "public",
+            "index":"all"
+        },
+        "request_method": "POST",
+        "stac_properties": {
+            "access": [
+                "HTTPServer"
+            ]
+        },
+        "stac_properties_map": {
+            "datetime": "acquisitionDate",
+            "updated": "lastUpdateDate",
+            "gsd": "resolution",
+            "eo:cloud_cover": "cloudCover",
+            "eo:snow_cover": "snowCover",
+            "view:azimuth": "azimuthAngle",
+            "view:sun_azimuth": "illuminationAzimuthAngle",
+            "view:sun_elevation": "illuminationElevationAngle",
+            "view:incidence_angle": "incidenceAngle"
+
+        },
+        "external_urls": [
+            {
+                "name": "quicklook",
+                "path": "_links.quicklook.href"
+            },
+            {
+                "name": "thumbnail",
+                "path": "_links.thumbnail.href"
+            }
+        ],
+        "stac_extensions": [
+            "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+            "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+            "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+        ],
+        "item_id_key": "acquisitionIdentifier",
+        "pagination_method": "counter"
+    },
+    "PHR": {
+        "collection_name": "airbus_phr_data",
+        "url": "https://search.foundation.api.oneatlas.airbus.com/api/v2/opensearch",
+        "auth_env": null,
+        "body": {
+            "itemsPerPage": 200,
+            "sortBy": "-lastUpdateDate",
+            "startPage": 1,
+            "constellation": "PHR",
+            "processingLevel": "ALBUM",
+            "workspace": "public",
+            "index":"all"
+        },
+        "request_method": "POST",
+        "stac_properties": {
+            "access": [
+                "HTTPServer"
+            ]
+        },
+        "stac_properties_map": {
+            "datetime": "acquisitionDate",
+            "updated": "lastUpdateDate",
+            "gsd": "resolution",
+            "eo:cloud_cover": "cloudCover",
+            "eo:snow_cover": "snowCover",
+            "view:azimuth": "azimuthAngle",
+            "view:sun_azimuth": "illuminationAzimuthAngle",
+            "view:sun_elevation": "illuminationElevationAngle",
+            "view:incidence_angle": "incidenceAngle"
+
+        },
+        "external_urls": [
+            {
+                "name": "quicklook",
+                "path": "_links.quicklook.href"
+            },
+            {
+                "name": "thumbnail",
+                "path": "_links.thumbnail.href"
+            }
+        ],
+        "stac_extensions": [
+            "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+            "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+            "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+        ],
+        "item_id_key": "acquisitionIdentifier",
+        "pagination_method": "counter"
+    },
+    "PNEO": {
+        "collection_name": "airbus_pneo_data",
+        "url": "https://search.foundation.api.oneatlas.airbus.com/api/v2/opensearch",
+        "auth_env": "prod",
+        "body": {
+            "itemsPerPage": 200,
+            "sortBy": "-lastUpdateDate",
+            "constellation": "PNEO",
+            "startPage": 1,
+            "processingLevel": "ALBUM",
+            "workspace": "public-pneo",
+            "index":"all"
+        },
+        "request_method": "POST",
+        "stac_properties": {
+            "access": [
+                "HTTPServer"
+            ]
+        },
+        "stac_properties_map": {
+            "datetime": "acquisitionDate",
+            "updated": "lastUpdateDate",
+            "gsd": "resolution",
+            "eo:cloud_cover": "cloudCover",
+            "eo:snow_cover": "snowCover",
+            "view:azimuth": "azimuthAngle",
+            "view:sun_azimuth": "illuminationAzimuthAngle",
+            "view:sun_elevation": "illuminationElevationAngle",
+            "view:incidence_angle": "incidenceAngle"
+
+        },
+        "external_urls": [
+            {
+                "name": "quicklook",
+                "path": "_links.quicklook.href"
+            },
+            {
+                "name": "thumbnail",
+                "path": "_links.thumbnail.href"
+            }
+        ],
+        "stac_extensions": [
+            "https://stac-extensions.github.io/eo/v2.0.0/schema.json",
+            "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+            "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+        ],
+        "item_id_key": "acquisitionIdentifier",
+        "pagination_method": "counter"
+    }
+}

--- a/airbus_harvester/config_schema.json
+++ b/airbus_harvester/config_schema.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Harvester Configuration",
+    "type": "object",
+    "properties": {
+        "collection_name": {
+            "type": "string",
+            "description": "Name of the STAC collection."
+        },
+        "url": {
+            "type": "string",
+            "description": "API endpoint for the data."
+        },
+        "auth_env": {
+            "type": ["string", "null"],
+            "description": "Airbus environment used for authentication if required.",
+            "enum": ["prod", "dev"]
+        },
+        "body": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "description": "Request body for the API call, if applicable."
+        },
+        "request_method": {
+            "type": "string",
+            "description": "HTTP method for the API request.",
+            "enum": ["GET", "POST"]
+        },
+        "stac_properties": {
+            "type": "object",
+            "description": "STAC properties common across all STAC items."
+        },
+        "stac_properties_map": {
+            "type": "object",
+            "description": "Mapping of STAC properties to API response fields."
+        },
+        "external_urls": {
+            "type": "array",
+            "description": "External URLs to be added as links and assets.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the external URL in STAC."
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Path to the external URL in the API response."
+                    }
+                }
+            }
+        },
+        "stac_extensions": {
+            "type": "array",
+            "description": "List of STAC extensions used.",
+            "items": {
+                "type": "string"
+            }
+        },
+        "item_id_key": {
+            "type": "string",
+            "description": "Key within the API response to be used as the STAC item ID."
+        },
+        "pagination_method": {
+            "type": "string",
+            "description": "Method used for pagination in the API.",
+            "enum": ["link", "counter"]
+        }
+    }
+}


### PR DESCRIPTION
Added configuration files to the airbus harvester. These allow us to share the general code and flow for all optical and radar Airbus harvesters. Differences include but are not limited to:

- PNEO and SAR require auth, PHR and SPOT do not
- Different STAC collection templates
- Different endpoints or request body

A schema for the config file has been supplied for documentation purposes only.
The harvesters are deployed to all but the SAR harvester on dev, using version 0.1.5-rc1