### PR TITLE
Feature/eodhp 999 refactoring to use messanger framework

### DIFF
--- a/airbus_harvester/__main__.py
+++ b/airbus_harvester/__main__.py
@@ -351,7 +351,7 @@ def get_stac_collection_summary(all_data: dict) -> dict:
     }
 
 
-def generate_stac_collection(all_data_summary: dict, config: dict) -> str:
+def generate_stac_collection(all_data_summary: dict, config: dict) -> dict:
     """Top level collection for Airbus data"""
 
     stac_template = load_config(f"airbus_harvester/{config['collection_name']}.json")
@@ -360,7 +360,7 @@ def generate_stac_collection(all_data_summary: dict, config: dict) -> str:
         "spatial": {"bbox": [all_data_summary["bbox"]]},
         "temporal": {"interval": [[all_data_summary["start_time"], all_data_summary["stop_time"]]]},
     }
-    return json.dumps(stac_template, indent=4)
+    return stac_template
 
 
 def handle_external_url(

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -355,9 +355,8 @@ def test_generate_stac_collection(mock_data, mock_config):
     }
 
     actual_collection = generate_stac_collection(mock_data_summary, mock_config)
-    json_collection = json.loads(actual_collection)
 
-    assert isinstance(actual_collection, str)
+    assert isinstance(actual_collection, dict)
     assert {
         "type",
         "id",
@@ -372,7 +371,7 @@ def test_generate_stac_collection(mock_data, mock_config):
         "keywords",
         "summaries",
         "item_assets",
-    }.issubset(set(json_collection.keys()))
+    }.issubset(set(actual_collection.keys()))
 
 
 def test_handle_external_url__with_quicklook(mock_config):


### PR DESCRIPTION
## Update Collection Return Type
- Ensure `generate_stac_collection` function returns dict, as required by new Messager class, not string