### PR TITLE
Use TOPIC extension from env var

### DIFF
--- a/airbus_harvester/__main__.py
+++ b/airbus_harvester/__main__.py
@@ -54,9 +54,14 @@ def harvest(workspace_name: str, catalog: str, s3_bucket: str):
     config_key = os.getenv("HARVESTER_CONFIG_KEY", "")
     config = load_config("airbus_harvester/config.json").get(config_key.upper())
 
+    if os.getenv("TOPIC"):
+        identifier = "_" + os.getenv("TOPIC")
+    else:
+        identifier = ""
+
     pulsar_client = get_pulsar_client()
     producer = pulsar_client.create_producer(
-        topic="harvested",
+        topic=f"harvested{identifier}",
         producer_name=f"stac_harvester/airbus/{config['collection_name']}",
         chunking_enabled=True,
     )


### PR DESCRIPTION
## Added TOPIC Env Var to Allow Pulsar Topic Configuration
- Read from env var `TOPIC` and appended to the standard `harvested` topic