### PR TITLE
Update descriptions; add thumbnail links

### DIFF
--- a/airbus_harvester/__main__.py
+++ b/airbus_harvester/__main__.py
@@ -424,6 +424,9 @@ def generate_stac_collection(all_data_summary: dict, config: dict) -> dict:
         "spatial": {"bbox": [all_data_summary["bbox"]]},
         "temporal": {"interval": [[all_data_summary["start_time"], all_data_summary["stop_time"]]]},
     }
+    for _asset_name, asset in stac_template.get("assets").items():
+        if "href" in asset:
+            asset["href"] = asset["href"].replace("{EODHP_BASE_URL}", proxy_base_url)
     return stac_template
 
 

--- a/airbus_harvester/airbus_phr_data.json
+++ b/airbus_harvester/airbus_phr_data.json
@@ -3,7 +3,7 @@
     "id": "airbus_phr_data",
     "stac_version": "1.0.0",
     "stac_extensions": [],
-    "description": "The identical Pléiades 1A and Pléiades 1B satellites deliver 50cm imagery products with a 20km swath. Their location accuracy and image quality are excellent, making them an ideal source of data for both civil or military projects. The space and ground segment have been designed to provide data in record time, ensuring daily revisit capacity anywhere on the globe and unrivalled reliability when it comes to collecting new images.",
+    "description": "The Pléiades constellation is Airbus' main very high resolution programme, expanding and consolidating on the SPOT legacy with the identical Pléiades 1A and Pléiades 1B launched in 2011 and 2012. These satellites operate as a true constellation, combining a twice-daily revisit capability with an ingenious range of resolutions. Pléiades collects imagery with a 50 cm panchromatic and four 2 m multispectral bands across a 20 km swath, making them an ideal source of data for a wide range of environmental, civil, and military needs.",
     "links": [],
     "title": "Airbus PHR Data",
     "geometry": {
@@ -29,6 +29,15 @@
         "constellation": [
             "PHR"
         ]
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "{EODHP_BASE_URL}/api/catalogue/stac/catalogs/commercial/catalogs/airbus/collections/airbus_phr_data/thumbnail",
+        "type": "image/jpg",
+        "roles": [
+          "thumbnail"
+        ]
+      }
     },
     "item_assets": {
         "thumbnail": {

--- a/airbus_harvester/airbus_pneo_data.json
+++ b/airbus_harvester/airbus_pneo_data.json
@@ -3,7 +3,7 @@
     "id": "airbus_pneo_data",
     "stac_version": "1.0.0",
     "stac_extensions": [],
-    "description": "Experience the forefront of Earth observation innovation with Pléiades Neo - Airbus's leading optical constellation featuring two identical 30cm resolution satellites renowned for their ultimate reactivity. Since its launch in 2021, this innovative constellation has revolutionised the landscape of Earth observation-based services, setting new standards of precision and reliability. Funded, manufactured, owned, and operated entirely by Airbus, Pléiades Neo reflects their unfailing commitment to excellence. Through meticulous optimisation of every stage of the imagery acquisition and delivery cycle, Airbus guarantees the provision of top-level Earth observation services.",
+    "description": "Pléiades Neo is Airbus' industry-leading very high-resolution optical constellation of two identical satellites phased at 180° from each other. The constellation provides continuity for the Pléiades mission, with enhanced performance in terms of accuracy, reactivity and frequency. Pléiades Neo provides users with 30 cm native resolution panchromatic imagery, and six 1.2 m multispectral bands, offering the best of very high-resolution optical imagery for an unprecedented level of geospatial services.",
     "links": [],
     "title": "Airbus PNEO Data",
     "geometry": {
@@ -29,6 +29,15 @@
         "constellation": [
             "PNEO"
         ]
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "{EODHP_BASE_URL}/api/catalogue/stac/catalogs/commercial/catalogs/airbus/collections/airbus_pneo_data/thumbnail",
+        "type": "image/jpg",
+        "roles": [
+          "thumbnail"
+        ]
+      }
     },
     "item_assets": {
         "thumbnail": {

--- a/airbus_harvester/airbus_sar_data.json
+++ b/airbus_harvester/airbus_sar_data.json
@@ -6,7 +6,7 @@
         "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
         "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
     ],
-    "description": "The German TerraSAR-X / TanDEM-X satellite formation and the Spanish PAZ satellite (managed by Hisdesat Servicios Estratégicos S.A.) are being operated in the same orbit tube and feature identical ground swaths and imaging modes - allowing Airbus and Hisdesat to establish a unique commercial Radar Constellation. The satellites carry a high frequency X-band Synthetic Aperture Radar (SAR) sensor in order to acquire datasets ranging from very high-resolution imagery to wide area coverage.",
+    "description": "The TerraSAR-X and TanDEM-X satellites carry high frequency X-band Synthetic Aperture Radar (SAR) sensors in order to acquire datasets ranging from very high-resolution imagery to wide area coverage. Using spaceborne SAR we can provide accurate measurements, unmatched geometric accuracy and provide highly precise information of any point on Earth. Our imagery ranges from very high resolution to wide-area coverage. The satellites' proven data quality and resolution of up to 25 cm continues to be among the very best in the spaceborne commercial radar market. The constellation's capacity empowers both data-hungry services and time-critical missions, enabling a broad array of applications, including maritime monitoring, change detection, and interferometry.",
     "links": [],
     "title": "Airbus SAR Data",
     "geometry": {
@@ -95,6 +95,15 @@
             "right",
             "left"
         ]
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "{EODHP_BASE_URL}/api/catalogue/stac/catalogs/commercial/catalogs/airbus/collections/airbus_sar_data/thumbnail",
+        "type": "image/jpg",
+        "roles": [
+          "thumbnail"
+        ]
+      }
     },
     "item_assets": {
         "thumbnail": {

--- a/airbus_harvester/airbus_spot_data.json
+++ b/airbus_harvester/airbus_spot_data.json
@@ -3,7 +3,7 @@
     "id": "airbus_spot_data",
     "stac_version": "1.0.0",
     "stac_extensions": [],
-    "description": "The SPOT (from French \"Satellite pour l'Observation de la Terre\") series has been supplying high-resolution, wide-area optical imagery since 1986. The latest satellites in the series, SPOT 6 and SPOT 7, are commercial satellites owned by Airbus Defence and Space, and assure data continuity through to 2024. All of the SPOT satellites provide imagery in panchromatic and multispectral bands with a swath of 60 km.",
+    "description": "SPOT is designed to efficiently cover huge areas in record time, making it a perfect choice for cartography and monitoring applications. The SPOT satellites build upon a legacy of data that began 30 years ago with the launch of the original SPOT 1 satellite in 1986. This legacy means that today, users have access to a vast archive of high-resolution imagery collected over the past decade, spanning billions of km² and offering unique historical insights. Every day SPOT acquires 3 million km² of imagery with 1.5 m panchromatic and 6 m multispectral bands.",
     "links": [],
     "title": "Airbus SPOT Data",
     "geometry": {
@@ -29,6 +29,15 @@
         "constellation": [
             "SPOT"
         ]
+    },
+    "assets": {
+      "thumbnail": {
+        "href": "{EODHP_BASE_URL}/api/catalogue/stac/catalogs/commercial/catalogs/airbus/collections/airbus_spot_data/thumbnail",
+        "type": "image/jpg",
+        "roles": [
+          "thumbnail"
+        ]
+      }
     },
     "item_assets": {
         "thumbnail": {

--- a/airbus_harvester/config.json
+++ b/airbus_harvester/config.json
@@ -13,7 +13,7 @@
             "sar:center_frequency": 9.65
         },
         "stac_properties_map": {
-            "datetime": "catalogueTime",
+            "datetime": "startTime",
             "start_datetime": "startTime",
             "end_datetime": "stopTime",
             "updated": "lastUpdateTime",


### PR DESCRIPTION
Updates descriptions for airbus collections
Adds links for collection thumbnails, which go via the thumbnail proxy
bugfix: datetime for SAR data is now the start time of the data. Catalogue time is when it was ingested into OneAtlas, so is not relevant for old data.